### PR TITLE
fix(trim): preserve file mode bits and report physical-deletion set in audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to Chopper are recorded here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`chopper trim` no longer drops file mode bits** on rebuilt files.
+  Previously every file written into `<domain>/` (FULL_COPY or PROC_TRIM)
+  came out with default-umask permissions because `Path.write_text`
+  ignores the source's `st_mode`. Executable scripts (Tcl/Perl/csh/Python
+  entry points, helper drivers, etc.) lost their `+x` bit on every trim,
+  silently breaking flows that invoked them by execution. The trim
+  writer now mirrors the source mode via `shutil.copymode` after each
+  write.
+
+- **`files_removed.txt` now reports the full physical-deletion set.**
+  Previously the artifact only listed files whose manifest treatment was
+  explicitly `REMOVE`, missing the much larger set of files chopper
+  silently dropped via the documented "default is exclude" rule (i.e.
+  files no `files.include` pattern matched). The audit bundle therefore
+  contained no flat list of what actually disappeared from the rebuilt
+  domain. The writer now computes the deletion set as
+  `walk(<domain>_backup/) − manifest_kept_files`, which captures both
+  explicit `REMOVE` decisions and default-exclude drops. When no backup
+  exists (e.g. `validate`-only runs) the writer falls back to the prior
+  REMOVE-only behaviour and the header line records which mode was used.
+
 ### Added
 
 #### Task A — `files_removed.txt` audit artifact

--- a/src/chopper/audit/service.py
+++ b/src/chopper/audit/service.py
@@ -55,7 +55,7 @@ class AuditService:
         renderings.append(render_trim_report_json(ctx, record))
         renderings.append(render_trim_report_txt(ctx, record))
         renderings.append(render_trim_stats(ctx, record))
-        renderings.append(render_files_removed(record))
+        renderings.append(render_files_removed(ctx, record))
         renderings.append(render_files_kept(record))
 
         # Preserve input files as exact byte-for-byte copies.

--- a/src/chopper/audit/writers.py
+++ b/src/chopper/audit/writers.py
@@ -354,22 +354,92 @@ def render_trim_report_txt(ctx: ChopperContext, record: RunRecord) -> tuple[str,
 # ---------------------------------------------------------------------------
 
 
-def render_files_removed(record: RunRecord) -> tuple[str, str]:
-    """Flat sorted list of domain-relative paths that will be removed.
+_KEPT_TREATMENTS = frozenset({FileTreatment.FULL_COPY, FileTreatment.PROC_TRIM, FileTreatment.GENERATED})
 
-    One POSIX path per line, alphabetically sorted.  The file is empty
-    (header only) when the manifest is absent or no files are marked
-    ``REMOVE``.  Useful during ``--dry-run`` to review the removal set
-    without parsing ``trim_report.json``.
+
+def _walk_relative_files(ctx: ChopperContext, root: Path) -> list[Path]:
+    """Recursively list files under ``root`` relative to ``root``.
+
+    Uses :attr:`ctx.fs` so the audit layer stays adapter-agnostic. Skips
+    a top-level ``.chopper/`` subtree (chopper's own audit bundle should
+    never be reported as a domain file). Returns ``[]`` if ``root`` does
+    not exist.
     """
 
+    if not ctx.fs.exists(root):
+        return []
+    out: list[Path] = []
+    stack: list[Path] = [root]
+    while stack:
+        current = stack.pop()
+        try:
+            children = list(ctx.fs.list(current))
+        except (FileNotFoundError, NotADirectoryError):
+            continue
+        for child in children:
+            # Skip the audit bundle if it sits at the top level.
+            if child.parent == root and child.name == ".chopper":
+                continue
+            try:
+                stat = ctx.fs.stat(child)
+            except FileNotFoundError:
+                continue
+            if stat.is_dir:
+                stack.append(child)
+            else:
+                out.append(child.relative_to(root))
+    return out
+
+
+def render_files_removed(ctx: ChopperContext, record: RunRecord) -> tuple[str, str]:
+    """Flat sorted list of domain-relative paths that the trim physically removed.
+
+    The "removal set" is computed by walking ``<domain>_backup/`` (the
+    pre-trim source of truth) and taking the set difference against the
+    files the manifest decided to keep (``FULL_COPY``, ``PROC_TRIM``,
+    ``GENERATED``). This therefore captures **both** explicit ``REMOVE``
+    decisions in the manifest **and** files that were silently dropped by
+    chopper's "default is exclude" behavior — i.e. files that no
+    ``files.include`` pattern matched.
+
+    When the backup directory does not exist (e.g. ``validate``-only run,
+    or ``--dry-run`` against a domain that was never previously trimmed),
+    the writer falls back to listing only the manifest's explicit
+    ``REMOVE`` entries. The header line documents which mode was used so
+    consumers can tell the two apart at a glance.
+
+    One POSIX path per line, alphabetically sorted. The file is empty
+    (header only) when nothing was removed.
+    """
+
+    backup_root = ctx.config.backup_root
     manifest = record.manifest
-    lines: list[str] = ["# files_removed.txt — paths scheduled for removal"]
-    if manifest is not None:
-        removed = sorted(
-            p.as_posix() for p, t in manifest.file_decisions.items() if t is FileTreatment.REMOVE
+
+    if ctx.fs.exists(backup_root):
+        kept_rel: set[Path] = set()
+        if manifest is not None:
+            kept_rel = {p for p, t in manifest.file_decisions.items() if t in _KEPT_TREATMENTS}
+        backup_files = set(_walk_relative_files(ctx, backup_root))
+        removed_paths = sorted(p.as_posix() for p in (backup_files - kept_rel))
+        header = (
+            "# files_removed.txt — paths physically removed from the rebuilt domain "
+            "(present in <domain>_backup/, absent from the rebuilt <domain>/)"
         )
-        lines.extend(removed)
+    else:
+        # Fallback: no backup to walk. Honour whatever the manifest said
+        # explicitly; this mirrors chopper's pre-fix behaviour.
+        removed_paths = []
+        if manifest is not None:
+            removed_paths = sorted(
+                p.as_posix() for p, t in manifest.file_decisions.items() if t is FileTreatment.REMOVE
+            )
+        header = (
+            "# files_removed.txt — paths scheduled for explicit removal "
+            "(no <domain>_backup/ available; physical-deletion set cannot be computed)"
+        )
+
+    lines: list[str] = [header]
+    lines.extend(removed_paths)
     lines.append("")
     return "files_removed.txt", "\n".join(lines)
 
@@ -377,7 +447,7 @@ def render_files_removed(record: RunRecord) -> tuple[str, str]:
 def render_files_kept(record: RunRecord) -> tuple[str, str]:
     """Flat sorted list of domain-relative paths that will be kept.
 
-    One POSIX path per line, alphabetically sorted.  Includes files
+    One POSIX path per line, alphabetically sorted. Includes files
     with ``FULL_COPY``, ``PROC_TRIM``, and ``GENERATED`` treatments.
     The file is empty (header only) when the manifest is absent.
     Useful during ``--dry-run`` to verify the survival set at a glance.
@@ -386,10 +456,7 @@ def render_files_kept(record: RunRecord) -> tuple[str, str]:
     manifest = record.manifest
     lines: list[str] = ["# files_kept.txt — paths that survive trimming"]
     if manifest is not None:
-        _kept_treatments = {FileTreatment.FULL_COPY, FileTreatment.PROC_TRIM, FileTreatment.GENERATED}
-        kept = sorted(
-            p.as_posix() for p, t in manifest.file_decisions.items() if t in _kept_treatments
-        )
+        kept = sorted(p.as_posix() for p, t in manifest.file_decisions.items() if t in _KEPT_TREATMENTS)
         lines.extend(kept)
     lines.append("")
     return "files_kept.txt", "\n".join(lines)

--- a/src/chopper/trimmer/file_writer.py
+++ b/src/chopper/trimmer/file_writer.py
@@ -8,10 +8,26 @@ bundle at P7 describes the planned result identically.
 The helpers never emit diagnostics themselves — the owning
 :class:`TrimmerService` emits ``VE-23`` / ``VE-24`` / ``VE-25`` /
 ``VE-26`` in the dispatch loop.
+
+File-mode preservation
+----------------------
+After writing each rebuilt file (``FULL_COPY`` or ``PROC_TRIM``) we mirror
+the source file's mode bits from ``<domain>_backup/`` onto the freshly
+written destination via :func:`shutil.copymode`. ``Path.write_text`` (used
+by :class:`~chopper.adapters.fs_local.LocalFS`) creates the destination
+with the process umask, which silently drops the executable bit and
+collapses group/world permissions; without this step every rebuilt
+``.tcl`` / ``.pl`` / ``.csh`` / ``.py`` script that was executable in the
+input domain comes out non-executable in the rebuilt domain. The copy is
+gated on the destination actually existing on the real filesystem so it
+is a no-op for in-memory filesystem adapters used by unit tests, and the
+``OSError`` swallow keeps the trim resilient to unusual filesystems
+(e.g. NFS exports that reject ``chmod``).
 """
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 from chopper.core.context import ChopperContext
@@ -29,6 +45,23 @@ def _domain_path(ctx: ChopperContext, rel: Path) -> Path:
     return ctx.config.domain_root / rel
 
 
+def _mirror_mode(src: Path, dst: Path) -> None:
+    """Copy ``src``'s mode bits onto ``dst`` if both are real on-disk paths.
+
+    No-op when either path is absent from the real filesystem (the unit-test
+    in-memory adapter never materializes paths on disk) or when the platform
+    rejects ``chmod`` for any reason. Errors here must never break a trim:
+    the destination content is already correct; only the perms are at risk.
+    """
+
+    try:
+        if src.is_file() and dst.is_file():
+            shutil.copymode(src, dst)
+    except OSError:
+        # Defensive: keep the trim alive on filesystems that reject chmod.
+        pass
+
+
 def full_copy_file(ctx: ChopperContext, rel: Path, *, procs_in_file: tuple[str, ...]) -> FileOutcome:
     """Copy ``rel`` verbatim from backup to the rebuilt domain."""
 
@@ -38,6 +71,7 @@ def full_copy_file(ctx: ChopperContext, rel: Path, *, procs_in_file: tuple[str, 
     bytes_in = len(content.encode("utf-8"))
     if not ctx.config.dry_run:
         ctx.fs.write_text(dst, content)
+        _mirror_mode(src, dst)
     return FileOutcome(
         path=rel,
         treatment=FileTreatment.FULL_COPY,
@@ -74,6 +108,7 @@ def proc_trim_file(
     bytes_out = len(new_content.encode("utf-8"))
     if not ctx.config.dry_run:
         ctx.fs.write_text(dst, new_content)
+        _mirror_mode(src, dst)
 
     return FileOutcome(
         path=rel,

--- a/technical_docs/chopper_description.md
+++ b/technical_docs/chopper_description.md
@@ -653,7 +653,7 @@ All examples below assume Chopper is invoked from the domain root. The current w
 - `dependency_graph.json` — full proc trace results including `source`/`iproc_source` and proc call edges
 - `trim_report.json` — what would be trimmed, and why each file/proc survives or is removed
 - `trim_report.txt` — human-readable projection of `trim_report.json`
-- `files_removed.txt` — flat sorted list of domain-relative paths scheduled for removal (one path per line)
+- `files_removed.txt` — flat sorted list of domain-relative paths physically removed from the rebuilt domain (one path per line). Computed as `files in <domain>_backup/ - files kept by the manifest`, so it captures both **explicit** `REMOVE` decisions and files **silently dropped by the default-exclude rule** (i.e. files no `files.include` pattern matched). When `<domain>_backup/` is not present (e.g. `validate`-only run) the writer falls back to listing only the manifest's explicit `REMOVE` entries; the file's header line records which mode was used.
 - `files_kept.txt` — flat sorted list of domain-relative paths that survive trimming (one path per line)
 - log with all diagnostics emitted with severity, code, location, and hint fields
 
@@ -1270,6 +1270,7 @@ This walkthrough expands the pipeline diagram into the concrete data flow each p
   - `PROC_TRIM` → read the file from backup, delete the line spans of every proc not in `surviving_procs(F)`, rewrite directly into the rebuilt `domain/` tree.
   - `GENERATED` → run the F3 generator (`flow_actions` is authoritative for ordering here).
   - `REMOVE` → record the omission; do not write.
+- For both `FULL_COPY` and `PROC_TRIM`, after the destination is written its mode bits are mirrored from the source file in `<domain>_backup/` (via `shutil.copymode`). This preserves executable bits and group/other permissions across the rebuild — without this step the destination would inherit the process umask and silently lose `+x` on every script.
 - Write `.chopper/trim_report.json` and `trim_report.txt` describing every file and proc operation and the diagnostics correlated with each.
 - Owner: `trimmer/` + `generators/`.
 - Output: the rebuilt `domain/` tree plus the trim-report artifacts. If P5 fails mid-run, the partially rebuilt `domain/` is left in place and the intact `<domain>_backup/` is the recovery source for the next invocation.

--- a/tests/unit/audit/test_audit.py
+++ b/tests/unit/audit/test_audit.py
@@ -203,10 +203,11 @@ def test_render_chopper_run_includes_mode_and_counts() -> None:
 
 
 def test_render_files_removed_empty_record_produces_header_only() -> None:
-    name, content = render_files_removed(_record())
+    ctx = _make_ctx()
+    name, content = render_files_removed(ctx, _record())
     assert name == "files_removed.txt"
     assert content.startswith("# files_removed.txt")
-    # No paths present when manifest is absent.
+    # No paths present when manifest is absent and backup directory does not exist.
     lines = [line for line in content.splitlines() if line and not line.startswith("#")]
     assert lines == []
 
@@ -233,10 +234,111 @@ def test_render_files_removed_lists_remove_paths_sorted() -> None:
             p_rem2: FileProvenance(path=p_rem2, treatment=FileTreatment.REMOVE, reason="default-exclude"),
         },
     )
-    _, content = render_files_removed(_record(manifest=manifest))
+    # No backup populated on the filesystem -> fallback path lists the
+    # manifest's explicit REMOVE entries.
+    ctx = _make_ctx()
+    _, content = render_files_removed(ctx, _record(manifest=manifest))
     data_lines = [line for line in content.splitlines() if line and not line.startswith("#")]
     assert data_lines == ["a_first.tcl", "z_last.tcl"]
     assert "lib/keep.tcl" not in content
+    # Header should call out the fallback mode.
+    assert "no <domain>_backup/ available" in content
+
+
+def test_render_files_removed_includes_default_exclude_drops_when_backup_present() -> None:
+    """Regression for the bug where ``files_removed.txt`` only listed
+    explicit ``REMOVE`` decisions, missing files silently dropped by
+    chopper's "default is exclude" rule. With ``<domain>_backup/`` present
+    on disk, the writer must compute the physical-deletion set as
+    ``backup_files - manifest_kept_files``."""
+
+    p_kept_copy = Path("kept_full.tcl")
+    p_kept_trim = Path("lib/kept_trim.tcl")
+    # Three files exist in backup that the manifest never enumerated -> they
+    # were silently dropped by default-exclude. They must appear in the
+    # removed list even though they have no manifest entry at all.
+    p_dropped_a = Path("default_drop_a.tcl")
+    p_dropped_b = Path("subdir/default_drop_b.pl")
+    p_dropped_c = Path("subdir/nested/default_drop_c.csh")
+    # And one file that the manifest explicitly marks REMOVE.
+    p_explicit = Path("explicit_remove.tcl")
+
+    fs = InMemoryFS()
+    for rel in (p_kept_copy, p_kept_trim, p_dropped_a, p_dropped_b, p_dropped_c, p_explicit):
+        fs.write_text(BACKUP / rel, "# placeholder\n")
+
+    manifest = CompiledManifest(
+        file_decisions={
+            p_explicit: FileTreatment.REMOVE,
+            p_kept_copy: FileTreatment.FULL_COPY,
+            p_kept_trim: FileTreatment.PROC_TRIM,
+        },
+        proc_decisions={},
+        provenance={
+            p_explicit: FileProvenance(
+                path=p_explicit,
+                treatment=FileTreatment.REMOVE,
+                reason="default-exclude",
+            ),
+            p_kept_copy: FileProvenance(
+                path=p_kept_copy,
+                treatment=FileTreatment.FULL_COPY,
+                reason="fi-literal",
+                input_sources=("base:files.include",),
+            ),
+            p_kept_trim: FileProvenance(
+                path=p_kept_trim,
+                treatment=FileTreatment.PROC_TRIM,
+                reason="pi-additive",
+                input_sources=("base:procedures.include",),
+                proc_model="additive",
+            ),
+        },
+    )
+
+    ctx = _make_ctx(fs=fs)
+    _, content = render_files_removed(ctx, _record(manifest=manifest))
+    data_lines = [line for line in content.splitlines() if line and not line.startswith("#")]
+    assert data_lines == [
+        "default_drop_a.tcl",
+        "explicit_remove.tcl",
+        "subdir/default_drop_b.pl",
+        "subdir/nested/default_drop_c.csh",
+    ]
+    # Surviving files must NOT show up in the removal set.
+    assert "kept_full.tcl" not in content
+    assert "lib/kept_trim.tcl" not in content
+    # Header should advertise the new physical-deletion semantics.
+    assert "physically removed" in content
+
+
+def test_render_files_removed_skips_chopper_audit_dir() -> None:
+    """The audit bundle directory itself must never be reported as a
+    domain file removed by trimming."""
+
+    fs = InMemoryFS()
+    fs.write_text(BACKUP / "real.tcl", "# real\n")
+    # Stage a file under an in-backup .chopper/ directory; it must be ignored.
+    fs.write_text(BACKUP / ".chopper" / "diagnostics.json", "{}")
+
+    manifest = CompiledManifest(
+        file_decisions={Path("real.tcl"): FileTreatment.FULL_COPY},
+        proc_decisions={},
+        provenance={
+            Path("real.tcl"): FileProvenance(
+                path=Path("real.tcl"),
+                treatment=FileTreatment.FULL_COPY,
+                reason="fi-literal",
+                input_sources=("base:files.include",),
+            ),
+        },
+    )
+
+    ctx = _make_ctx(fs=fs)
+    _, content = render_files_removed(ctx, _record(manifest=manifest))
+    data_lines = [line for line in content.splitlines() if line and not line.startswith("#")]
+    assert data_lines == []
+    assert ".chopper" not in content
 
 
 def test_render_files_kept_empty_record_produces_header_only() -> None:
@@ -287,9 +389,6 @@ def test_render_files_kept_lists_surviving_paths_sorted() -> None:
     data_lines = [line for line in content.splitlines() if line and not line.startswith("#")]
     assert data_lines == ["a_trim.tcl", "synth.tcl", "z_copy.tcl"]
     assert "drop.tcl" not in content
-
-
-
 
 
 def test_audit_service_writes_bundle_with_empty_record() -> None:

--- a/tests/unit/trimmer/test_file_writer_modes.py
+++ b/tests/unit/trimmer/test_file_writer_modes.py
@@ -1,0 +1,155 @@
+"""Mode-bit preservation tests for the trimmer's per-file write helpers.
+
+These tests exercise :func:`chopper.trimmer.file_writer.full_copy_file` and
+:func:`chopper.trimmer.file_writer.proc_trim_file` against a *real*
+``LocalFS`` adapter and ``tmp_path``, because the bug they cover is
+specifically about ``Path.write_text`` not propagating source ``st_mode``.
+The in-memory adapter used elsewhere in :mod:`chopper.trimmer` has no
+notion of file modes, so this regression cannot be caught against it.
+
+The bug was: every file rebuilt by ``chopper trim`` came out with default
+umask permissions instead of the mode bits the source file had in
+``<domain>_backup/``. Concretely, every executable script in the input
+domain lost its ``+x`` bit on the rebuilt side.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+from chopper.adapters import LocalFS
+from chopper.core.context import ChopperContext, RunConfig
+from chopper.core.diagnostics import Diagnostic, DiagnosticSummary, Phase
+from chopper.core.models import ParsedFile, ProcEntry
+from chopper.trimmer.file_writer import full_copy_file, proc_trim_file
+
+
+class _NullSink:
+    def emit(self, d: Diagnostic) -> None: ...  # pragma: no cover
+    def snapshot(self) -> tuple[Diagnostic, ...]: ...  # pragma: no cover
+    def finalize(self) -> DiagnosticSummary: ...  # pragma: no cover
+
+
+class _NullProgress:
+    def phase_started(self, phase: Phase) -> None: ...  # pragma: no cover
+    def phase_done(self, phase: Phase) -> None: ...  # pragma: no cover
+    def step(self, message: str) -> None: ...  # pragma: no cover
+
+
+def _make_ctx(tmp_path: Path, *, dry_run: bool = False) -> ChopperContext:
+    domain = tmp_path / "domain"
+    backup = tmp_path / "domain_backup"
+    audit = domain / ".chopper"
+    domain.mkdir()
+    backup.mkdir()
+    cfg = RunConfig(
+        domain_root=domain,
+        backup_root=backup,
+        audit_root=audit,
+        strict=False,
+        dry_run=dry_run,
+    )
+    return ChopperContext(config=cfg, fs=LocalFS(), diag=_NullSink(), progress=_NullProgress())
+
+
+def _executable_mode(p: Path) -> bool:
+    return bool(p.stat().st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
+
+
+def test_full_copy_file_preserves_executable_bit(tmp_path: Path) -> None:
+    """Regression: a ``+x`` source file in backup must remain ``+x`` after FULL_COPY."""
+
+    ctx = _make_ctx(tmp_path)
+    rel = Path("run_me.tcl")
+    src = ctx.config.backup_root / rel
+    src.write_text("#!/usr/bin/env tclsh\nputs hi\n")
+    os.chmod(src, 0o755)
+    assert _executable_mode(src), "fixture sanity: src must be +x before trim"
+
+    full_copy_file(ctx, rel, procs_in_file=())
+
+    dst = ctx.config.domain_root / rel
+    assert dst.is_file()
+    src_mode = stat.S_IMODE(src.stat().st_mode)
+    dst_mode = stat.S_IMODE(dst.stat().st_mode)
+    assert dst_mode == src_mode, f"FULL_COPY did not preserve mode bits: src=0o{src_mode:o} dst=0o{dst_mode:o}"
+    assert _executable_mode(dst)
+
+
+def test_full_copy_file_preserves_non_executable_mode(tmp_path: Path) -> None:
+    """A non-executable source must end up non-executable (and exact-mode-equal)."""
+
+    ctx = _make_ctx(tmp_path)
+    rel = Path("data/notes.txt")
+    src = ctx.config.backup_root / rel
+    src.parent.mkdir(parents=True)
+    src.write_text("just text\n")
+    os.chmod(src, 0o640)
+
+    full_copy_file(ctx, rel, procs_in_file=())
+
+    dst = ctx.config.domain_root / rel
+    assert stat.S_IMODE(dst.stat().st_mode) == 0o640
+    assert not _executable_mode(dst)
+
+
+def test_proc_trim_file_preserves_executable_bit(tmp_path: Path) -> None:
+    """Same regression for the PROC_TRIM rewrite path: rewriting content
+    must not strip the source ``+x`` bit."""
+
+    ctx = _make_ctx(tmp_path)
+    rel = Path("trim_me.tcl")
+    src = ctx.config.backup_root / rel
+    src.write_text("proc keep {} { puts ok }\nproc drop {} { puts bye }\n")
+    os.chmod(src, 0o755)
+    assert _executable_mode(src)
+
+    keep = ProcEntry(
+        canonical_name=f"{rel.as_posix()}::keep",
+        short_name="keep",
+        qualified_name="keep",
+        source_file=rel,
+        start_line=1,
+        end_line=1,
+        body_start_line=1,
+        body_end_line=1,
+        namespace_path="::",
+    )
+    drop = ProcEntry(
+        canonical_name=f"{rel.as_posix()}::drop",
+        short_name="drop",
+        qualified_name="drop",
+        source_file=rel,
+        start_line=2,
+        end_line=2,
+        body_start_line=2,
+        body_end_line=2,
+        namespace_path="::",
+    )
+    parsed = ParsedFile(path=rel, procs=(keep, drop), encoding="utf-8")
+
+    proc_trim_file(ctx, rel, parsed=parsed, keep_canonical=frozenset({keep.canonical_name}))
+
+    dst = ctx.config.domain_root / rel
+    assert dst.is_file()
+    assert stat.S_IMODE(dst.stat().st_mode) == stat.S_IMODE(src.stat().st_mode)
+    assert _executable_mode(dst)
+
+
+def test_dry_run_does_not_touch_destination(tmp_path: Path) -> None:
+    """Dry-run must remain side-effect free; mode preservation has no opportunity to fire."""
+
+    ctx = _make_ctx(tmp_path, dry_run=True)
+    rel = Path("preview_me.tcl")
+    src = ctx.config.backup_root / rel
+    src.write_text("# hi\n")
+    os.chmod(src, 0o755)
+
+    outcome = full_copy_file(ctx, rel, procs_in_file=())
+
+    dst = ctx.config.domain_root / rel
+    assert not dst.exists(), "dry-run must not create the destination file"
+    # Outcome is still produced so the audit bundle can describe the planned action.
+    assert outcome.path == rel


### PR DESCRIPTION
## Summary

Fixes two related bugs in the live `chopper trim` path, both surfaced while running chopper against the sta_pt PrimeTime signoff domain (issue #15 plus a companion mode-bits bug filed in parallel):

1. **`chopper trim` silently dropped file mode bits on every rebuilt file.** Every `FULL_COPY` / `PROC_TRIM` write went through `Path.write_text`, which creates the destination with the process umask. The source file's `st_mode` was never propagated, so every rebuilt file came out with default-umask perms — collapsing the executable bit on every script. In sta_pt: 113 files lost `+x`. The audit bundle reported the run as a clean success (`exit 0`, no warnings).

2. **`files_removed.txt` only listed explicit `REMOVE` decisions.** Files silently dropped by chopper's documented "default is exclude" rule (i.e. files no `files.include` pattern matched) were physically deleted from the rebuilt domain but never appeared in `files_removed.txt`. In sta_pt: 161 files were physically removed; 0 appeared in the artifact. ← issue #15

## Fixes

### `src/chopper/trimmer/file_writer.py` — mode preservation

After each `ctx.fs.write_text(dst, content)` in `full_copy_file` and `proc_trim_file`, mirror the source mode via a small `_mirror_mode(src, dst)` helper that calls `shutil.copymode`. The call is gated on both src and dst being real on-disk files (so the in-memory adapter used by the rest of the trimmer test suite is unaffected) and wrapped in a defensive `OSError` swallow so unusual filesystems (e.g. NFS exports rejecting `chmod`) cannot break a trim that already wrote correct content.

### `src/chopper/audit/writers.py` — physical-deletion set

`render_files_removed` now takes `ctx` and walks `<domain>_backup/`, computing the deletion set as `backup_files − manifest_kept_files` (where kept = `FULL_COPY ∪ PROC_TRIM ∪ GENERATED`). This naturally captures both explicit `REMOVE` decisions **and** files dropped by default-exclude. The walk skips a top-level `.chopper/` subtree so the audit bundle never reports itself as a removed domain file.

When `<domain>_backup/` does not exist (e.g. `validate`-only run, or `--dry-run` against a never-trimmed domain), the writer falls back to the prior REMOVE-only behaviour. The header line on `files_removed.txt` records which mode was used so consumers can tell the two apart at a glance.

`audit/service.py` updated to pass `ctx` to the new signature.

## Tests

New `tests/unit/trimmer/test_file_writer_modes.py` (4 tests) — exercises `full_copy_file` and `proc_trim_file` against a real `LocalFS` + `tmp_path`:
- `test_full_copy_file_preserves_executable_bit` — 0o755 source survives FULL_COPY.
- `test_full_copy_file_preserves_non_executable_mode` — 0o640 mode preserved exactly.
- `test_proc_trim_file_preserves_executable_bit` — 0o755 source survives PROC_TRIM rewrite.
- `test_dry_run_does_not_touch_destination` — dry-run remains side-effect free.

`tests/unit/audit/test_audit.py` updated:
- Existing `test_render_files_removed_*` tests updated for the new `(ctx, record)` signature.
- New `test_render_files_removed_includes_default_exclude_drops_when_backup_present` — backup populated with kept + dropped files; only the dropped set appears in the artifact (regression for #15).
- New `test_render_files_removed_skips_chopper_audit_dir` — top-level `.chopper/` ignored.

## Docs cascade (per CONTRIBUTING.md)

- `technical_docs/chopper_description.md` §P5 now documents the post-write `shutil.copymode` step.
- Same file's dry-run output table re-explains `files_removed.txt`'s new physical-deletion semantics including the fallback case.
- `CHANGELOG.md` Unreleased / Fixed entries added for both bugs.

## Validation

- **Tests**: 859 unit + 29 integration + 5 golden + 4 property → all green on this branch.
- **Format**: `ruff format --check` clean on all touched files.
- **Type-check**: `mypy` clean on touched source files.
- **Service signatures**: no `Service.run` signatures changed; doc-gate not affected.
- **Diagnostic registry**: no new diagnostic codes added.

### Pre-existing gate failures, NOT introduced by this PR

Three Makefile gates fail identically on `main` independent of this branch — confirmed by checking out `main` and re-running:

1. `make lint` — `ruff` reports `I001` on `src/chopper/compiler/merge_service.py` (un-sorted imports). Last touched by commit `f4ebadc` "feat: Enhance diagnostic path handling and fix parser issues".
2. `make imports-check` — `lint-imports` flags two cross-layer imports (`chopper.validator → chopper.config.service`; `chopper.config → chopper.compiler.tool_commands`).
3. `make docs-gate` — both helper scripts can't find their inputs because the `Makefile` calls `python scripts/check_*.py` but the scripts actually live in `schemas/scripts/`.

Happy to address any of those in a follow-up PR if desired, but they are out of scope for this fix and would expand the diff well beyond the two bugs.

## Files changed

```
 CHANGELOG.md                                       |  23 +++
 src/chopper/audit/service.py                       |   2 +-
 src/chopper/audit/writers.py                       |  99 ++++++++++++--
 src/chopper/trimmer/file_writer.py                 |  35 +++++
 technical_docs/chopper_description.md              |   3 +-
 tests/unit/audit/test_audit.py                     | 111 +++++++++++++++-
 tests/unit/trimmer/test_file_writer_modes.py (new) | 154 +++++++++++++++++++++
```

## Checklist

- [x] Tests run for the touched area (897 tests pass on this branch).
- [x] `ruff format --check` and `mypy` pass on all touched files.
- [x] No new diagnostics introduced (so DIAGNOSTIC_CODES.md unchanged).
- [x] User-facing docs updated (`technical_docs/chopper_description.md` P5 + dry-run output table).
- [x] CHANGELOG entry added.
- [x] No out-of-scope features introduced.
